### PR TITLE
Add darwin x86_64

### DIFF
--- a/libc/libc.ml
+++ b/libc/libc.ml
@@ -1,6 +1,9 @@
 module Impl = Libc_aarch64_apple_darwin
 [@@config all (target_os = "macos", target_arch = "aarch64")]
 
+module Impl = Libc_aarch64_apple_darwin
+[@@config all (target_os = "macos", target_arch = "x86_64")]
+
 module Impl = Libc_x86_64_linux_gnu
 [@@config all (target_os = "linux", target_arch = "x86_64", target_env = "gnu")]
 


### PR DESCRIPTION
This builds fine and allowed me to install riot without issue. 
This bypasses the bug in `config.ml` which isn't allowing the following:
```
[@@config all (target_os = "macos")]
```
