### PR TITLE
Add template for opam file

### DIFF
--- a/libc.opam
+++ b/libc.opam
@@ -30,3 +30,4 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocaml-sys/libc.ml.git"
+available: arch != "x86_32" & arch != "arm32" & arch != "ppc64" & arch != "s390x"

--- a/libc.opam.template
+++ b/libc.opam.template
@@ -1,0 +1,1 @@
+available: arch != "x86_32" & arch != "arm32" & arch != "ppc64" & arch != "s390x"


### PR DESCRIPTION
to make the package unavailable on unsupported architectures. See https://github.com/ocaml/opam-repository/pull/25074#discussion_r1485946922 for reference.